### PR TITLE
Fix:「戻る」のリンク先と編集ページのタイトルを変更

### DIFF
--- a/server.js
+++ b/server.js
@@ -83,17 +83,19 @@ app.get('/admin/edit', (request, response) => {
     title: '',
     content: ''
   };
+  let pageTitle = '記事の新規投稿';
 
   // dateパラメータありの場合は記事の編集なので該当の記事データを取得してセットする
   if (request.query.date) {
     entry = func.fileNameToEntry(request.query.date + '.txt', false);
+    pageTitle = '記事の編集(' + func.convertDateFormat(entry.date) + ')';
   }
-  response.render('edit', { entry });
+  response.render('edit', { entry, pageTitle });
 });
 
 app.post('/admin/post_entry', (request, response) => {
-  func.saveEntry(request.body.date, request.body.title, request.body.content)
-  response.redirect('/blog/');
+  func.saveEntry(request.body.date, request.body.title, request.body.content);
+  response.redirect('/admin/');
 });
 
 // Expressサーバー起動

--- a/views/edit.ejs
+++ b/views/edit.ejs
@@ -3,7 +3,9 @@
 
 <head>
   <meta charset="utf-8">
-  <title>記事の新規投稿 | 管理者用ページ</title>
+  <title>
+    <%= pageTitle %> | 管理者用ページ
+  </title>
   <link rel="stylesheet" href="/admin.css">
 </head>
 
@@ -11,7 +13,9 @@
   <h1>管理者用ページ</h1>
 
   <section>
-    <h2>記事の新規投稿</h2>
+    <h2>
+      <%= pageTitle %>
+    </h2>
     <form name="edit" action="/admin/post_entry" method="post">
       <div>
         <h3>タイトル</h3>
@@ -24,7 +28,7 @@
       <div class="form-buttons">
         <input type="hidden" name="date" value="<%= entry.date %>">
         <input type="submit" value="送信">
-        <a href="/blog/">戻る</a>
+        <a href="/admin/">戻る</a>
       </div>
     </form>
   </section>


### PR DESCRIPTION
##概要
・編集ページの「戻る」のリンク先を/adminに変更。
・編集ページのタイトルを記事の編集(編集した日の日付)になるように変更。
