### PR TITLE
Fix:パスワードをハッシュ化できるようにルーティング修正

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -6,6 +6,9 @@ const path = require('path');
 // ブログ記事テキストファイルが保存されているフォルダ
 const entriesDir = path.join(__dirname, 'entries');
 
+// ハッシュ化パスワードの保存先ファイル
+const passwordFile = path.join(__dirname, '/.password');
+
 /**
  * ブログ記事フォルダ内のファイル名一覧をファイル名の降順でソートした配列で取得
  */
@@ -126,6 +129,16 @@ function getDateString(date = new Date()) {
   return ymd;
 }
 
+/**
+   * パスワードをファイルから取得
+   */
+function loadPassword() {
+  if (fs.existsSync(passwordFile)) {
+    return fs.readFileSync(passwordFile, 'utf-8');
+  }
+  return null;
+}
+
 // 外部ファイルから参照できる関数の公開設定
 module.exports = {
   getEntryFiles,
@@ -135,5 +148,6 @@ module.exports = {
   saveEntry,
   convertDateFormat,
   getDateString,
-  deleteEntry
+  deleteEntry,
+  loadPassword
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "bcryptjs": "^2.4.3",
+        "crypto-random-string": "^3.3.1",
         "ejs": "^3.1.3",
         "express": "^4.17.1",
         "nodemon": "^2.0.15"
@@ -103,6 +105,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -420,9 +427,20 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "node_modules/crypto-random-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-3.3.1.tgz",
+      "integrity": "sha512-5j88ECEn6h17UePrLi6pn1JcLtAiANa3KExyr9y9Z5vo2mv56Gh3I4Aja/B9P9uyMwyxNHAHWv+nE72f30T5Dg==",
+      "dependencies": {
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "engines": {
         "node": ">=8"
       }
@@ -1596,6 +1614,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/unique-string/node_modules/crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1896,6 +1922,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -2132,9 +2163,19 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "crypto-random-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-3.3.1.tgz",
+      "integrity": "sha512-5j88ECEn6h17UePrLi6pn1JcLtAiANa3KExyr9y9Z5vo2mv56Gh3I4Aja/B9P9uyMwyxNHAHWv+nE72f30T5Dg==",
+      "requires": {
+        "type-fest": "^0.8.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+        }
+      }
     },
     "debug": {
       "version": "2.6.9",
@@ -3009,6 +3050,13 @@
       "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
       "requires": {
         "crypto-random-string": "^2.0.0"
+      },
+      "dependencies": {
+        "crypto-random-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+          "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
+        }
       }
     },
     "unpipe": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,12 @@
   "description": "Techpit「実務を意識した JavaScript の WEB システム開発体験を通して知識と考え方を身に付けよう！」教材プロジェクト",
   "main": "server.js",
   "scripts": {
-    "start": "nodemon server.js"
+    "start": "nodemon server.js",
+    "reset": "node password-reset.js"
   },
   "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "crypto-random-string": "^3.3.1",
     "ejs": "^3.1.3",
     "express": "^4.17.1",
     "nodemon": "^2.0.15"

--- a/password-reset.js
+++ b/password-reset.js
@@ -1,0 +1,17 @@
+// ランダム文字列生成パッケージを読み込み
+const cryptoRandomString = require('crypto-random-string');
+// パスワードハッシュ化パッケージを読み込み
+const bcrypt = require('bcryptjs');
+// Node.js内蔵のファイル操作モジュールを読み込み
+const fs = require('fs');
+// Node.js内蔵のファイルパス関連モジュールを読み込み
+const path = require('path');
+
+// 初期パスワードを生成(ランダム8文字)
+const initPassword = cryptoRandomString({
+  length: 8
+});
+// ハッシュ化パスワードを作成して保存
+const hashed = bcrypt.hashSync(initPassword);
+fs.writeFileSync(path.join(__dirname, '.password'), hashed);
+console.log('パスワードを初期化しました。: ' + initPassword);

--- a/server.js
+++ b/server.js
@@ -1,5 +1,9 @@
 // Expressサーバーパッケージを読み込み
 const express = require('express');
+
+// パスワードハッシュ化パッケージを読み込み
+const bcrypt = require('bcryptjs');
+
 // 同じフォルダにあるfunctions.jsを読み込み
 const func = require('./functions');
 
@@ -67,7 +71,8 @@ app.get('/login', (request, response) => {
 });
 
 app.post('/auth', (request, response) => {
-  if (request.body.password === 'password') {
+  const hashed = func.loadPassword();
+  if (hashed && bcrypt.compareSync(request.body.password, hashed)) {
     response.redirect('/admin/');
   } else {
     response.redirect('/login?failed=1');


### PR DESCRIPTION
##概要
・パスワードハッシュ化のためのパッケージbcryptjsとランダムな文字列を生成するcrypto-random-stringをダウンロード及び読み込み。
・/authルーティングでのパスワードの認証方法を変更。